### PR TITLE
Relax semantic versioning for moment package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/ElekenAgency/ReactNativeWheelPicker",
   "dependencies": {
-    "moment": "2.22.0"
+    "moment": "^2.22.0"
   }
 }


### PR DESCRIPTION
Constraining the exact version of package results in 99% of the cases in the need to include an extra version of the package to the bundle (which in case of `moment` is almost `52KB`).

With `^` we are solving this problem without a risk of introducing breaking changes.