### PR TITLE
Android - fix TimePicker initDate

### DIFF
--- a/src/TimePicker.js
+++ b/src/TimePicker.js
@@ -75,7 +75,8 @@ export default class TimePicker extends React.Component<Props, State> {
           {...this.props}
           data={hours}
           onItemSelected={this.onHourSelected}
-          initPosition={selectedHourIndex}
+          selectedItem={selectedHourIndex}
+          initPosition={0}
         />
         <WheelPicker
           style={styles.wheelPicker}
@@ -83,7 +84,8 @@ export default class TimePicker extends React.Component<Props, State> {
           {...this.props}
           data={minutes}
           onItemSelected={this.onMinuteSelected}
-          initPosition={selectedMinuteIndex}
+          selectedItem={selectedMinuteIndex}
+          initPosition={0}
         />
         {!this.props.format24 && this.renderAm()}
       </View>

--- a/src/TimePicker.js
+++ b/src/TimePicker.js
@@ -75,7 +75,6 @@ export default class TimePicker extends React.Component<Props, State> {
           {...this.props}
           data={hours}
           onItemSelected={this.onHourSelected}
-          selectedItem={selectedHourIndex}
           initPosition={selectedHourIndex}
         />
         <WheelPicker
@@ -84,7 +83,6 @@ export default class TimePicker extends React.Component<Props, State> {
           {...this.props}
           data={minutes}
           onItemSelected={this.onMinuteSelected}
-          selectedItem={selectedMinuteIndex}
           initPosition={selectedMinuteIndex}
         />
         {!this.props.format24 && this.renderAm()}


### PR DESCRIPTION
Use selectedItem & initPosition together will mess up time picker's initial date, 
and selectedItem is not necessary for time picker (date picker doesn't have it too)

Edit:
remove `selectedItem` will break the scrolling