### PR TITLE
feat(date-picker): display a custom date format for date picker

### DIFF
--- a/src/DatePicker.android.js
+++ b/src/DatePicker.android.js
@@ -31,6 +31,7 @@ type Props = {
   hideHours?: boolean,
   hideMinutes?: boolean,
   hideAM?: boolean,
+  format?: string
 }
 
 type State = {
@@ -97,6 +98,7 @@ export default class DatePicker extends React.Component<Props, State> {
       hideHours,
       hideMinutes,
       hideAM,
+      format,
     } = this.props
     const { initHourInex, initDayInex, initMinuteInex } = this.state
     return (
@@ -104,7 +106,7 @@ export default class DatePicker extends React.Component<Props, State> {
         {!hideDate && <WheelPicker
           style={styles.dateWheelPicker}
           {...this.props}
-          data={days || pickerDateArray(startDate, daysCount)}
+          data={days || pickerDateArray(startDate, daysCount, format)}
           onItemSelected={this.onDaySelected}
           initPosition={initDayInex}
         />}
@@ -153,7 +155,7 @@ export default class DatePicker extends React.Component<Props, State> {
       days,
       daysCount
     } = this.props
-    const data = days || pickerDateArray(startDate, daysCount)
+    const data = days || pickerDateArray(startDate, daysCount, format)
     if (data[position] === 'Today') {
       selectedDate = new Date()
     } else {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -5,6 +5,8 @@
 
 import moment from 'moment'
 
+const DEFAULT_DATE_PICKER_FORMAT = 'ddd MMM D'
+
 const AM = 'AM'
 const PM = 'PM'
 const YEAR = 365
@@ -45,7 +47,7 @@ export function increaseDateByDays(date: Date, numOfDays: ?number) {
     return nextDate
 }
 
-export function pickerDateArray(date: string, daysCount: number = YEAR) {
+export function pickerDateArray(date: string, daysCount: number = YEAR, datePickerFormat: string = DEFAULT_DATE_PICKER_FORMAT) {
     const startDate = date ? new Date(date) : new Date()
     const arr = []
 
@@ -57,15 +59,15 @@ export function pickerDateArray(date: string, daysCount: number = YEAR) {
         }
         else {
             arr.push(
-                formatDatePicker(ithDateFromStartDate)
+                formatDatePicker(ithDateFromStartDate, datePickerFormat)
             )
         }
     }
     return arr
 }
 
-function formatDatePicker(date: number) {
-    return moment.unix(date).format('ddd MMM D');
+function formatDatePicker(date: number, format: string) {
+    return moment.unix(date).format(format);
 }
 
 export function getHoursArray(format24: boolean) {


### PR DESCRIPTION
On my mobile app, I would like to display another format than ddd MMM D. So that's why I created this PR, the goal is to be able to give a custom date format.

## iOS
Component tested `DatePickerIOS`
### Locale: `FR` with format `ddd D MMMM`
![image](https://user-images.githubusercontent.com/10991546/65591023-0d1e0f00-df8c-11e9-92fd-52bdab947a53.png)

### Locale: `EN` with format `ddd MMMM Do`
![image](https://user-images.githubusercontent.com/10991546/65591776-6d618080-df8d-11e9-99ec-08335d986981.png)

## Android
Component tested `DatePicker`
### Locale: `FR` with format `ddd D MMMM`
![image](https://user-images.githubusercontent.com/10991546/65591088-26bf5680-df8c-11e9-8714-d2e66a7ce7da.png)

### Locale: `EN` with format `ddd MMMM Do`
![image](https://user-images.githubusercontent.com/10991546/65591456-ddbbd200-df8c-11e9-8178-e5631f7b9f76.png)
